### PR TITLE
Width & Border Fix

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -7,7 +7,7 @@ body {
 
 iframe {
     position: absolute;
-    border:0;
+    border:none;
     top: 0px;
     left: 0px;
     height: 100%;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -37,14 +37,15 @@ $(function() {
             // Thanks ocbaker on github for finding this bug.
             var pageWidth = $('body').width();
             var maxSales = (pageWidth/70)*5
-            var xPos = getRandomInt(0, pageWidth);
+            var xPos = getRandomInt(0, 100);
             var percentOff = randomChoice(STEAM_SALES);
             // Just copy the hidden box we had at page load time to make a new box.
             var newSale = $saleBox.clone().show();
 
             newSale.text("-" + percentOff + "%"); // >js >strings
-
-            newSale.css("left", xPos);
+			
+            newSale.css("left", xPos + "%");
+			
             $('body').append(newSale);
 
             //Only have maxSales sale boxes onscreen at once.
@@ -125,6 +126,3 @@ $(function() {
 
     prepareWallet();
 });
-
-
-


### PR DESCRIPTION
1.) Sales now span the whole page when the window is resized (% width
rather than pixels)

2.) Border removed properly, page looks better while loading on slower
connections.